### PR TITLE
Improve anim state readability

### DIFF
--- a/src/player/ambient.toml
+++ b/src/player/ambient.toml
@@ -30,4 +30,4 @@ hero_model = { type = "EntityId", name = "is_hero", description = "is_hero", att
     "Networked",
 ] }
 
-anim_state = { type = { type = "Vec", element_type = "F32" } }
+anim_state = { type = { type = "Vec", element_type = "F32", description = "allows for better transitioning between animations, through use of Animation Blend in the future." } }

--- a/src/player/ambient.toml
+++ b/src/player/ambient.toml
@@ -30,4 +30,4 @@ hero_model = { type = "EntityId", name = "is_hero", description = "is_hero", att
     "Networked",
 ] }
 
-anim_state = { type = { type = "Vec", element_type = "F32", description = "allows for better transitioning between animations, through use of Animation Blend in the future." } }
+anim_state = { type = { type = "Vec", element_type = "F32", description = "allows for better transitioning between animations, through use of Animation Blend in the future. Currently it's a true/false vector for which animation is playing, but with 1.0 and 0.0 instead." } }

--- a/src/player/server.rs
+++ b/src/player/server.rs
@@ -22,11 +22,9 @@ use ambient_api::{
 
 const INIT_POS: f32 = std::f32::consts::FRAC_PI_2;
 
-macro_rules! idle_animation_state {
-    () => {
-        vec![1.0, 0.0, 0.0]
-    };
-}
+macro_rules! idle_animation_state { () => { vec![1.0, 0.0, 0.0] }; }
+macro_rules! walk_animation_state { () => { vec![0.0, 1.0, 0.0] }; }
+macro_rules! attack_animation_state { () => { vec![0.0, 0.0, 1.0] }; }
 
 #[main]
 pub fn main() {
@@ -44,9 +42,6 @@ pub fn main() {
         let idle_player = AnimationPlayer::new(&idle);
         let walk_player = AnimationPlayer::new(&walk);
         let attack_player = AnimationPlayer::new(&attack);
-
-        let walk_animation_state: Vec<f32> = vec![0.0, 1.0, 0.0];
-        let attack_animation_state: Vec<f32> = vec![0.0, 0.0, 1.0];
 
         // this is waiting for the ui server module to send a message
         println!("{:?} chose role {:?} in player module", source, msg.role);
@@ -123,7 +118,7 @@ pub fn main() {
                     let anim_state =
                         entity::get_component(anim_model, components::anim_state()).unwrap();
 
-                    if anim_state == vec![0.0, 0.0, 1.0] {
+                    if anim_state == attack_animation_state!() {
                         continue;
                     }
                     let current_pos = entity::get_component(model, translation()).unwrap();
@@ -136,7 +131,7 @@ pub fn main() {
                         physics::move_character(model, vec3(0., 0., -0.1), 0.01, delta_time());
                         // }
                         if entity::get_component(anim_model, components::anim_state()).unwrap()
-                            != vec![0.0, 0.0, 1.0]
+                            != attack_animation_state!()
                         {
                             entity::set_component(
                                 anim_model,
@@ -164,12 +159,12 @@ pub fn main() {
                     let speed = 0.05;
                     let displace = diff.normalize_or_zero() * speed;
 
-                    if anim_state != vec![0.0, 1.0, 0.0] {
+                    if anim_state != walk_animation_state!() {
                         entity::set_component(anim_model, apply_animation_player(), walk_player.0);
                         entity::set_component(
                             anim_model,
                             components::anim_state(),
-                            vec![0.0, 1.0, 0.0],
+                            walk_animation_state!(),
                         );
                     }
                     let collision = physics::move_character(

--- a/src/player/server.rs
+++ b/src/player/server.rs
@@ -38,6 +38,11 @@ pub fn main() {
         let idle_player = AnimationPlayer::new(&idle);
         let walk_player = AnimationPlayer::new(&walk);
         let attack_player = AnimationPlayer::new(&attack);
+
+        let idle_animation_state: Vec<f32> = vec![1.0, 0.0, 0.0];
+        let walk_animation_state: Vec<f32> = vec![0.0, 1.0, 0.0];
+        let attack_animation_state: Vec<f32> = vec![0.0, 0.0, 1.0];
+
         // this is waiting for the ui server module to send a message
         println!("{:?} chose role {:?} in player module", source, msg.role);
 

--- a/src/player/server.rs
+++ b/src/player/server.rs
@@ -100,7 +100,7 @@ pub fn main() {
             .with(translation(), vec3(0.0, 0.0, 0.8))
             .spawn();
         add_component(anim_model, apply_animation_player(), idle_player.0);
-        entity::add_component(anim_model, components::anim_state(), vec![1.0, 0.0]);
+        entity::add_component(anim_model, components::anim_state(), idle_animation_state!());
 
         entity::add_component(model, children(), vec![anim_model]);
         entity::add_component(player_id, components::role(), role);

--- a/src/player/server.rs
+++ b/src/player/server.rs
@@ -22,6 +22,12 @@ use ambient_api::{
 
 const INIT_POS: f32 = std::f32::consts::FRAC_PI_2;
 
+macro_rules! idle_animation_state {
+    () => {
+        vec![1.0, 0.0, 0.0]
+    };
+}
+
 #[main]
 pub fn main() {
     messages::ChooseRole::subscribe(|source, msg| {
@@ -39,7 +45,6 @@ pub fn main() {
         let walk_player = AnimationPlayer::new(&walk);
         let attack_player = AnimationPlayer::new(&attack);
 
-        let idle_animation_state: Vec<f32> = vec![1.0, 0.0, 0.0];
         let walk_animation_state: Vec<f32> = vec![0.0, 1.0, 0.0];
         let attack_animation_state: Vec<f32> = vec![0.0, 0.0, 1.0];
 
@@ -111,6 +116,7 @@ pub fn main() {
         entity::add_component(player_id, components::target_pos(), init_pos);
         query((player(), components::hero_model())).each_frame({
             move |list| {
+
                 for (player_id, (_, model)) in list {
                     let anim_model =
                         entity::get_component(player_id, components::anim_model()).unwrap();
@@ -140,7 +146,7 @@ pub fn main() {
                             entity::set_component(
                                 anim_model,
                                 components::anim_state(),
-                                vec![1.0, 0.0, 0.0],
+                                idle_animation_state!(),
                             );
                         };
                         continue;


### PR DESCRIPTION
A small PR that improves the readability of the values attributed to the anim_state component.

**Reasoning**

It took me a while to tinker with anim_state to figure out that it was, in the code current form, a true/false vector, but using F32 instead of bool. 

Replacing the same vectors called multiple times with a macro

* _allows for better understanding of what the code is doing;_
* _reduces the odds of someone writing the wrong vector in the wrong anim; (see example of that already happening below)_

Also, adding a description to anim_state

 * _avoids people falling in the same rabbit hole of "have to figure out what is this component and why it is important";_
 * _it also gives people a vision of what the component should also do in the future, and opens the door for someone to add animation blending;_

**Features**

* Adds a description to the anim_state component;
* Creates three macro for the vectors used by anim_state;
* Replaces vectors used to initialize/set anim_state with macro calls;
* Fixes one line (line 98 at the original src/player/server.rs, line 103 in the PR, same file) with a idle_animation_state vector - we should have an idle animation state vector there, but had only a vec with two values.